### PR TITLE
Remove O(n^2) behavior

### DIFF
--- a/lib/guard.js
+++ b/lib/guard.js
@@ -50,48 +50,56 @@ module.exports = function makeGuard (config) {
    */
   const groups = [];
 
-  // flatten agents
-  config.groups
-    .forEach(function (group) {
-      const accessibilityRules = group.rules
-        .filter(({ rule, path }) => !!path && ['allow', 'disallow'].includes(rule.toLowerCase()))
-        .reduce((group, { rule, path }) => {
-          const repeatedPath = group.find((rule) => rule.path === path);
-          if (repeatedPath) {
-            if (rule.toLowerCase() === 'allow') {
-              repeatedPath.rule = 'allow';
-            }
-          } else {
-            group.push({
-              rule,
-              path
-            });
-          }
-          return group;
-        }, /** @type {{ rule: string, path: string }[]} */([]))
-        .map(({ rule, path }) => ({
-          pattern: patterns.path(path),
-          allow: rule.toLowerCase() !== 'disallow'
-        }))
-        .sort(moreSpecificFirst);
+  for (const group of config.groups) {
+    // flatten agents
 
-      const indexabilityRules = group.rules
-        .filter(({ rule, path }) => !!path && ['noindex'].includes(rule.toLowerCase()))
-        .map(({ rule, path }) => ({
-          pattern: patterns.path(path),
-          allow: rule.toLowerCase() !== 'noindex'
-        }))
-        .sort(moreSpecificFirst);
+    /** @type {Map<string, 'allow' | 'disallow'>} */
+    const allowByPath = new Map();
 
-      group.agents
-        .forEach(function (agent) {
-          groups.push({
-            pattern: patterns.userAgent(agent),
-            accessibilityRules,
-            indexabilityRules
-          });
+    for (const { rule, path } of group.rules) {
+      const normalizedRule = rule.toLowerCase();
+      if (path && (normalizedRule === 'allow' || normalizedRule === 'disallow')) {
+        const repeatedPath = allowByPath.get(path);
+        const overwrite = repeatedPath && (normalizedRule === 'allow');
+        if (overwrite || !repeatedPath) {
+          allowByPath.set(path, normalizedRule);
+        }
+      }
+    }
+
+    /** @type {Rule[]} */
+    const accessibilityRules = [];
+    for (const [path, rule] of allowByPath.entries()) {
+      accessibilityRules.push({
+        pattern: patterns.path(path),
+        allow: rule !== 'disallow'
+      });
+    }
+
+    accessibilityRules.sort(moreSpecificFirst);
+
+    /** @type {Rule[]} */
+    const indexabilityRules = [];
+    for (const { rule, path } of group.rules) {
+      const normalizedRule = rule.toLowerCase();
+      if (path && normalizedRule === 'noindex') {
+        indexabilityRules.push({
+          pattern: patterns.path(path),
+          allow: false
         });
-    });
+      }
+    }
+
+    indexabilityRules.sort(moreSpecificFirst);
+
+    for (const agent of group.agents) {
+      groups.push({
+        pattern: patterns.userAgent(agent),
+        accessibilityRules,
+        indexabilityRules
+      });
+    }
+  }
 
   groups.sort(moreSpecificFirst);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "robots-txt-guard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robots-txt-guard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Validate urls against robots.txt rules.",
   "main": "lib/guard.js",
   "repository": {


### PR DESCRIPTION
Refactor to use fewer nested `array.find()`. It has O(n) behavior because it potentially iterates over all elements to find an item. In this case it was nested in a loop of size `n`. So it turned the whole algorithm O(n^2). I replaced it with a `Map` so that we can use map access instead of `find` for the same thing. This is O(1), so the whole algorithm is O(n) now instead of O(n^2).

On the problematic input that we had with the robots.txt of 12k lines this turns 144M iterations into 12k iterations. In terms of actual performance this changes the computation time from about 1000ms into about 20ms (50x perf improvement)